### PR TITLE
Add Hotspot Game link to navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,6 +208,9 @@
                     <a href="features.html" class="nav-link">Features</a>
                 </li>
                 <li class="nav-item">
+                    <a href="https://hotspotgame.online/" class="nav-link" target="_blank" rel="noopener">热点游戏</a>
+                </li>
+                <li class="nav-item">
                     <a href="contact.html" class="nav-link">Contact</a>
                 </li>
                 <li class="nav-item">


### PR DESCRIPTION
## Summary
- add a Hotspot Game item to the homepage navigation menu linking to https://hotspotgame.online/

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e0c23f91a08321af005dd7fed3ad00