### PR TITLE
Remove 热点游戏 link from homepage navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,9 +208,6 @@
                     <a href="features.html" class="nav-link">Features</a>
                 </li>
                 <li class="nav-item">
-                    <a href="https://hotspotgame.online/" class="nav-link" target="_blank" rel="noopener">热点游戏</a>
-                </li>
-                <li class="nav-item">
                     <a href="contact.html" class="nav-link">Contact</a>
                 </li>
                 <li class="nav-item">


### PR DESCRIPTION
### Motivation
- Remove an external "热点游戏" navigation item from the homepage to clean up the primary menu and remove the external link.
- Keep the navigation focused on site-owned pages like About, Features, Contact, and FAQ.

### Description
- Deleted the `<li>` element linking to `https://hotspotgame.online/` with the label `热点游戏` from `index.html`.
- Updated the homepage navigation markup so the menu now lists Home, About, Features, Contact, and FAQ only.

### Testing
- Served the site locally with `python -m http.server 8000` and the server started successfully. 
- Ran a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a screenshot, which completed and produced `artifacts/home-nav.png`. 
- Verified the modified `index.html` was staged and committed successfully to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a4d678f408321b9a1b092622cf71e)