### PR TITLE
Remove duplicate Page Summary from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,14 +547,6 @@
         </div>
     </footer>
 
-    <!-- Page Summary -->
-    <section class="page-summary">
-        <div class="container">
-            <h3>Page Summary</h3>
-            <p>This is the homepage of TopicPicture, a professional free online image resizer tool. Our platform allows users to resize images online without losing quality, supporting JPEG, PNG, WebP, and GIF formats. Key features include bulk image resizing, social media optimization, email-friendly compression, and mobile-responsive design. The tool processes images locally in your browser for maximum privacy and security. Perfect for resizing photos for Instagram, WhatsApp, Facebook, and other social media platforms, as well as optimizing images for websites and email attachments.</p>
-        </div>
-    </section>
-
     <script src="script.js"></script>
     <script src="quick-test.js"></script>
 </body>


### PR DESCRIPTION
### Motivation
- Remove a duplicated "Page Summary" section that appeared after the footer on the homepage to avoid redundant content and improve UX and SEO.
- Keep the homepage structure clean by ensuring the summary appears only once.

### Description
- Deleted the duplicate `<section class="page-summary">` block that was repeated after the footer in `index.html`.
- The change is a simple HTML cleanup with 8 lines removed from `index.html` and no functional code modified.

### Testing
- No automated tests were executed for this static HTML change.
- A repository search using `rg` and a file preview using `sed` were used to locate and verify the duplicate before removal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bad16b4a483219af02bc8e5738de6)