### PR TITLE
Add Minimal Poster Generator page with canvas preview and PNG export

### DIFF
--- a/about.html
+++ b/about.html
@@ -24,6 +24,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="poster-generator.html" class="nav-link">Poster Generator</a>
+                </li>
+                <li class="nav-item">
                     <a href="about.html" class="nav-link active">About</a>
                 </li>
                 <li class="nav-item">
@@ -87,6 +90,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/contact.html
+++ b/contact.html
@@ -24,6 +24,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="poster-generator.html" class="nav-link">Poster Generator</a>
+                </li>
+                <li class="nav-item">
                     <a href="about.html" class="nav-link">About</a>
                 </li>
                 <li class="nav-item">
@@ -228,6 +231,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/faq.html
+++ b/faq.html
@@ -119,6 +119,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="poster-generator.html" class="nav-link">Poster Generator</a>
+                </li>
+                <li class="nav-item">
                     <a href="about.html" class="nav-link">About</a>
                 </li>
                 <li class="nav-item">
@@ -359,6 +362,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/features.html
+++ b/features.html
@@ -24,6 +24,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="poster-generator.html" class="nav-link">Poster Generator</a>
+                </li>
+                <li class="nav-item">
                     <a href="about.html" class="nav-link">About</a>
                 </li>
                 <li class="nav-item">
@@ -266,6 +269,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/index.html
+++ b/index.html
@@ -205,6 +205,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="poster-generator.html" class="nav-link">Poster Generator</a>
+                </li>
+                <li class="nav-item">
                     <a href="about.html" class="nav-link">About</a>
                 </li>
                 <li class="nav-item">
@@ -515,6 +518,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/poster-generator.html
+++ b/poster-generator.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- Primary Meta Tags -->
+    <title>Minimal Poster Generator – Create Clean Social Media Posters</title>
+    <meta name="title" content="Minimal Poster Generator – Create Clean Social Media Posters">
+    <meta name="description" content="Create centered, minimal posters from text. Export high-resolution PNGs for social media. No sign-up required.">
+    <meta name="keywords" content="poster generator, minimal poster, social media poster, text poster, png export, wechat moments, instagram post, twitter image">
+    <meta name="author" content="TopicPicture">
+    <meta name="robots" content="index, follow">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://topicture.online/poster-generator.html">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://topicture.online/poster-generator.html">
+    <meta property="og:title" content="Minimal Poster Generator – Create Clean Social Media Posters">
+    <meta property="og:description" content="Create centered, minimal posters from text. Export high-resolution PNGs for social media. No sign-up required.">
+    <meta property="og:image" content="https://topicture.online/og-image.jpg">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://topicture.online/poster-generator.html">
+    <meta property="twitter:title" content="Minimal Poster Generator – Create Clean Social Media Posters">
+    <meta property="twitter:description" content="Create centered, minimal posters from text. Export high-resolution PNGs for social media. No sign-up required.">
+    <meta property="twitter:image" content="https://topicture.online/twitter-image.jpg">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Noto+Sans+SC:wght@400;500;700&family=Noto+Serif+SC:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="navbar">
+        <div class="nav-container">
+            <div class="nav-logo">
+                <i class="fas fa-image"></i>
+                <span>TopicPicture</span>
+            </div>
+            <ul class="nav-menu">
+                <li class="nav-item">
+                    <a href="index.html" class="nav-link">Home</a>
+                </li>
+                <li class="nav-item">
+                    <a href="resizer.html" class="nav-link">Image Resizer</a>
+                </li>
+                <li class="nav-item">
+                    <a href="poster-generator.html" class="nav-link active">Poster Generator</a>
+                </li>
+                <li class="nav-item">
+                    <a href="about.html" class="nav-link">About</a>
+                </li>
+                <li class="nav-item">
+                    <a href="features.html" class="nav-link">Features</a>
+                </li>
+                <li class="nav-item">
+                    <a href="contact.html" class="nav-link">Contact</a>
+                </li>
+                <li class="nav-item">
+                    <a href="faq.html" class="nav-link">FAQ</a>
+                </li>
+            </ul>
+            <div class="nav-actions">
+                <button class="bookmark-btn" onclick="bookmarkPage()" title="Bookmark this page">
+                    <i class="fas fa-bookmark"></i>
+                </button>
+                <button class="share-btn" onclick="sharePage()" title="Share this page">
+                    <i class="fas fa-share-alt"></i>
+                </button>
+            </div>
+            <div class="hamburger">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <section class="page-hero">
+        <div class="container">
+            <h1>Minimal Poster Generator</h1>
+            <p>Turn text into clean, centered posters for social media. Choose a size, pick a font, and export a crisp PNG in seconds.</p>
+        </div>
+    </section>
+
+    <!-- Poster Generator -->
+    <section class="poster-generator-section">
+        <div class="container">
+            <div class="section-heading">
+                <h2 class="section-title">Create a Poster in Under 30 Seconds</h2>
+                <p class="section-subtitle">Write your title and subtitle, select a social media size, and download a pixel-perfect PNG.</p>
+            </div>
+            <div class="poster-layout">
+                <div class="poster-controls">
+                    <div class="form-group">
+                        <label for="posterText">Poster Text</label>
+                        <textarea id="posterText" rows="6" placeholder="Main title line\nSubtitle line\nAnother subtitle"></textarea>
+                        <p class="form-hint">Line 1 is the main title. Lines 2+ are subtitles.</p>
+                    </div>
+                    <div class="poster-form-row">
+                        <div class="form-group">
+                            <label for="posterSize">Social Media Size</label>
+                            <select id="posterSize">
+                                <option value="wechat">WeChat Moments (1080 × 1920)</option>
+                                <option value="instagram">Instagram Post (1080 × 1080)</option>
+                                <option value="twitter">X (Twitter) (1200 × 675)</option>
+                                <option value="pinterest">Pinterest (1000 × 1500)</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="posterFont">Font Family</label>
+                            <select id="posterFont">
+                                <option value="'Inter', sans-serif">Inter</option>
+                                <option value="'Noto Sans SC', sans-serif">Noto Sans SC</option>
+                                <option value="'Noto Serif SC', serif">Noto Serif SC</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="poster-form-row">
+                        <div class="form-group">
+                            <label for="posterBackground">Background Color</label>
+                            <input type="color" id="posterBackground" value="#ffffff">
+                        </div>
+                        <div class="form-group">
+                            <label>Current Size</label>
+                            <div class="poster-size-pill" id="posterSizeLabel">1080 × 1920</div>
+                        </div>
+                    </div>
+                    <div class="form-actions">
+                        <button class="btn btn-primary" id="posterExportBtn" type="button">
+                            <i class="fas fa-download"></i>
+                            Export PNG
+                        </button>
+                    </div>
+                    <p class="form-hint">Your download will be named <strong>poster-{width}x{height}.png</strong>.</p>
+                </div>
+                <div class="poster-preview">
+                    <div class="poster-preview-frame">
+                        <canvas id="posterCanvas" width="1080" height="1920" aria-label="Poster preview"></canvas>
+                    </div>
+                    <ul class="poster-meta">
+                        <li><i class="fas fa-expand"></i><span id="posterMetaSize">1080 × 1920 px</span></li>
+                        <li><i class="fas fa-font"></i><span id="posterMetaFont">Inter</span></li>
+                        <li><i class="fas fa-palette"></i><span id="posterMetaBg">#FFFFFF</span></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- How it Works -->
+    <section class="info-section alt">
+        <div class="container">
+            <h2 class="section-title">How It Works</h2>
+            <ol class="info-steps">
+                <li><strong>Type your copy:</strong> Add a main title on line 1, then any subtitles on the next lines.</li>
+                <li><strong>Pick a layout size:</strong> Choose a preset for WeChat, Instagram, X, or Pinterest.</li>
+                <li><strong>Export instantly:</strong> Download a pixel-perfect PNG ready to post.</li>
+            </ol>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="faq-section">
+        <div class="container">
+            <div class="section-heading">
+                <h2 class="section-title">FAQ</h2>
+                <p class="section-subtitle">Everything you need to know before exporting your poster.</p>
+            </div>
+            <div class="faq-grid">
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h3>Can I edit fonts or sizes manually?</h3>
+                        <i class="fas fa-chevron-down"></i>
+                    </div>
+                    <div class="faq-answer">
+                        <p>No. Font sizes are auto-calculated to keep every poster balanced and centered.</p>
+                    </div>
+                </div>
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h3>Does the exported PNG match the selected size?</h3>
+                        <i class="fas fa-chevron-down"></i>
+                    </div>
+                    <div class="faq-answer">
+                        <p>Yes. The PNG uses the exact pixel dimensions of the preset you select.</p>
+                    </div>
+                </div>
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h3>Can I use these posters commercially?</h3>
+                        <i class="fas fa-chevron-down"></i>
+                    </div>
+                    <div class="faq-answer">
+                        <p>Absolutely. The included Google Fonts are free for commercial use.</p>
+                    </div>
+                </div>
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h3>Do you store my text or posters?</h3>
+                        <i class="fas fa-chevron-down"></i>
+                    </div>
+                    <div class="faq-answer">
+                        <p>No. Everything runs locally in your browser and nothing is uploaded.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <div class="footer-logo">
+                        <i class="fas fa-image"></i>
+                        <span>TopicPicture</span>
+                    </div>
+                    <p>TopicPicture is a free online AI tool that helps users convert text descriptions into images.</p>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Quick Links</h4>
+                    <ul>
+                        <li><a href="index.html">Home</a></li>
+                        <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="poster-generator.html">Poster Generator</a></li>
+                        <li><a href="about.html">About</a></li>
+                        <li><a href="features.html">Features</a></li>
+                        <li><a href="contact.html">Contact</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Support</h4>
+                    <ul>
+                        <li><a href="faq.html">FAQ</a></li>
+                        <li><a href="privacy-policy.html">Privacy Policy</a></li>
+                        <li><a href="terms.html">Terms of Service</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Connect</h4>
+                    <div class="social-links">
+                        <a href="#"><i class="fab fa-twitter"></i></a>
+                        <a href="#"><i class="fab fa-facebook"></i></a>
+                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a href="#"><i class="fab fa-linkedin"></i></a>
+                    </div>
+                </div>
+            </div>
+
+            <div class="footer-bottom">
+                <p>&copy; 2024 TopicPicture. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+    <script src="poster.js"></script>
+</body>
+</html>

--- a/poster.js
+++ b/poster.js
@@ -1,0 +1,160 @@
+const posterPresets = {
+    wechat: { width: 1080, height: 1920, label: 'WeChat Moments' },
+    instagram: { width: 1080, height: 1080, label: 'Instagram Post' },
+    twitter: { width: 1200, height: 675, label: 'X (Twitter)' },
+    pinterest: { width: 1000, height: 1500, label: 'Pinterest' }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    const textInput = document.getElementById('posterText');
+    const sizeSelect = document.getElementById('posterSize');
+    const fontSelect = document.getElementById('posterFont');
+    const backgroundInput = document.getElementById('posterBackground');
+    const sizeLabel = document.getElementById('posterSizeLabel');
+    const metaSize = document.getElementById('posterMetaSize');
+    const metaFont = document.getElementById('posterMetaFont');
+    const metaBg = document.getElementById('posterMetaBg');
+    const exportBtn = document.getElementById('posterExportBtn');
+    const canvas = document.getElementById('posterCanvas');
+
+    if (!canvas) {
+        return;
+    }
+
+    const ctx = canvas.getContext('2d');
+
+    const updateMeta = (preset) => {
+        const sizeText = `${preset.width} × ${preset.height}`;
+        sizeLabel.textContent = sizeText;
+        metaSize.textContent = `${sizeText} px`;
+        metaFont.textContent = fontSelect.options[fontSelect.selectedIndex].textContent;
+        metaBg.textContent = backgroundInput.value.toUpperCase();
+    };
+
+    const getLines = () => {
+        const rawLines = textInput.value.split('\n');
+        const cleaned = rawLines.map((line) => line.trim()).filter((line) => line.length > 0);
+        if (cleaned.length === 0) {
+            return ['Your Main Title', 'Supporting subtitle text'];
+        }
+        return cleaned;
+    };
+
+    const getTextColor = (hex) => {
+        const normalized = hex.replace('#', '');
+        const r = parseInt(normalized.substring(0, 2), 16) / 255;
+        const g = parseInt(normalized.substring(2, 4), 16) / 255;
+        const b = parseInt(normalized.substring(4, 6), 16) / 255;
+        const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+        return luminance > 0.6 ? '#111827' : '#f8fafc';
+    };
+
+    const renderPoster = () => {
+        const preset = posterPresets[sizeSelect.value];
+        canvas.width = preset.width;
+        canvas.height = preset.height;
+
+        ctx.fillStyle = backgroundInput.value;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        const lines = getLines();
+        const titleLine = lines[0];
+        const subtitleLines = lines.slice(1);
+
+        let titleSize = Math.round(canvas.width * 0.08);
+        let subtitleSize = Math.round(canvas.width * 0.04);
+        const lineGap = Math.round(canvas.width * 0.015);
+
+        const fontFamily = fontSelect.value;
+        const maxWidth = canvas.width * 0.9;
+
+        const measureMaxWidth = (tSize, sSize) => {
+            let maxLineWidth = 0;
+            ctx.font = `700 ${tSize}px ${fontFamily}`;
+            maxLineWidth = Math.max(maxLineWidth, ctx.measureText(titleLine).width);
+            subtitleLines.forEach((line) => {
+                ctx.font = `500 ${sSize}px ${fontFamily}`;
+                maxLineWidth = Math.max(maxLineWidth, ctx.measureText(line).width);
+            });
+            return maxLineWidth;
+        };
+
+        let widthScale = 1;
+        const widest = measureMaxWidth(titleSize, subtitleSize);
+        if (widest > maxWidth) {
+            widthScale = maxWidth / widest;
+        }
+
+        const totalLines = 1 + subtitleLines.length;
+        const titleHeight = titleSize * 1.15;
+        const subtitleHeight = subtitleLines.length ? subtitleSize * 1.2 * subtitleLines.length : 0;
+        const totalHeight = titleHeight + subtitleHeight + lineGap * (totalLines - 1);
+        const heightScale = totalHeight > canvas.height * 0.85 ? (canvas.height * 0.85) / totalHeight : 1;
+
+        const scale = Math.min(widthScale, heightScale, 1);
+        titleSize = Math.round(titleSize * scale);
+        subtitleSize = Math.round(subtitleSize * scale);
+
+        const textColor = getTextColor(backgroundInput.value);
+        ctx.fillStyle = textColor;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+
+        const titleHeightScaled = titleSize * 1.15;
+        const subtitleHeightScaled = subtitleLines.length ? subtitleSize * 1.2 * subtitleLines.length : 0;
+        const totalHeightScaled = titleHeightScaled + subtitleHeightScaled + lineGap * (totalLines - 1);
+        let currentY = (canvas.height - totalHeightScaled) / 2;
+
+        ctx.font = `700 ${titleSize}px ${fontFamily}`;
+        ctx.fillText(titleLine, canvas.width / 2, currentY);
+        currentY += titleHeightScaled + lineGap;
+
+        subtitleLines.forEach((line) => {
+            ctx.font = `500 ${subtitleSize}px ${fontFamily}`;
+            ctx.fillText(line, canvas.width / 2, currentY);
+            currentY += subtitleSize * 1.2 + lineGap;
+        });
+
+        updateMeta(preset);
+    };
+
+    const handleChange = () => {
+        renderPoster();
+    };
+
+    const handleExport = () => {
+        const preset = posterPresets[sizeSelect.value];
+        const link = document.createElement('a');
+        link.download = `poster-${preset.width}x${preset.height}.png`;
+        link.href = canvas.toDataURL('image/png');
+        link.click();
+    };
+
+    const attachFAQToggle = () => {
+        const faqItems = document.querySelectorAll('.faq-item');
+        if (!faqItems.length) return;
+        faqItems.forEach((item) => {
+            const question = item.querySelector('.faq-question');
+            if (!question) return;
+            question.addEventListener('click', () => {
+                const isActive = item.classList.contains('active');
+                faqItems.forEach((otherItem) => {
+                    if (otherItem !== item) {
+                        otherItem.classList.remove('active');
+                    }
+                });
+                item.classList.toggle('active', !isActive);
+            });
+        });
+    };
+
+    textInput.addEventListener('input', handleChange);
+    sizeSelect.addEventListener('change', handleChange);
+    fontSelect.addEventListener('change', handleChange);
+    backgroundInput.addEventListener('input', handleChange);
+    exportBtn.addEventListener('click', handleExport);
+
+    document.fonts.ready.then(renderPoster);
+    attachFAQToggle();
+    renderPoster();
+});

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -24,6 +24,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="poster-generator.html" class="nav-link">Poster Generator</a>
+                </li>
+                <li class="nav-item">
                     <a href="about.html" class="nav-link">About</a>
                 </li>
                 <li class="nav-item">
@@ -92,6 +95,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/resizer.html
+++ b/resizer.html
@@ -27,6 +27,9 @@
                     <a href="resizer.html" class="nav-link active">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="poster-generator.html" class="nav-link">Poster Generator</a>
+                </li>
+                <li class="nav-item">
                     <a href="about.html" class="nav-link">About</a>
                 </li>
                 <li class="nav-item">
@@ -172,6 +175,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>
                         <li><a href="contact.html">Contact</a></li>

--- a/sitemap.html
+++ b/sitemap.html
@@ -84,6 +84,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="poster-generator.html" class="nav-link">Poster Generator</a>
+                </li>
+                <li class="nav-item">
                     <a href="about.html" class="nav-link">About</a>
                 </li>
                 <li class="nav-item">
@@ -133,6 +136,7 @@
                     <ul class="sitemap-links">
                         <li><a href="index.html">Home - Free Image Resizer Online</a></li>
                         <li><a href="resizer.html">Image Resizer - Resize Images Without Losing Quality</a></li>
+                        <li><a href="poster-generator.html">Minimal Poster Generator - Create Clean Social Media Posters</a></li>
                         <li><a href="about.html">About Us - Learn About TopicPicture</a></li>
                         <li><a href="features.html">Features - Image Resizer Tool Capabilities</a></li>
                         <li><a href="contact.html">Contact - Get in Touch</a></li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -20,6 +20,12 @@
         <priority>0.9</priority>
     </url>
     <url>
+        <loc>https://topicture.online/poster-generator.html</loc>
+        <lastmod>2024-12-20</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.9</priority>
+    </url>
+    <url>
         <loc>https://topicture.online/about.html</loc>
         <lastmod>2024-12-20</lastmod>
         <changefreq>monthly</changefreq>

--- a/styles.css
+++ b/styles.css
@@ -1775,3 +1775,99 @@ body {
         padding: 0 1.5rem 1rem;
     }
 }
+
+/* Poster Generator */
+.poster-generator-section {
+    padding: 80px 0;
+    background: var(--background);
+}
+
+.poster-layout {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 2.5rem;
+    align-items: start;
+}
+
+.poster-controls,
+.poster-preview {
+    background: white;
+    border-radius: var(--border-radius-lg);
+    padding: 2rem;
+    box-shadow: var(--shadow);
+}
+
+.poster-form-row {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.poster-size-pill {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 16px;
+    border-radius: var(--border-radius);
+    background: var(--background-alt);
+    border: 2px solid var(--border-color);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.poster-preview {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.poster-preview-frame {
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.05), rgba(99, 102, 241, 0.08));
+    border-radius: var(--border-radius-lg);
+    padding: 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 360px;
+}
+
+.poster-preview canvas {
+    width: 100%;
+    height: auto;
+    max-height: 70vh;
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow-lg);
+    background: white;
+}
+
+.poster-meta {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.poster-meta li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.poster-meta i {
+    color: var(--primary-color);
+}
+
+@media (max-width: 900px) {
+    .poster-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 600px) {
+    .poster-form-row {
+        grid-template-columns: 1fr;
+    }
+}

--- a/terms.html
+++ b/terms.html
@@ -24,6 +24,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="poster-generator.html" class="nav-link">Poster Generator</a>
+                </li>
+                <li class="nav-item">
                     <a href="about.html" class="nav-link">About</a>
                 </li>
                 <li class="nav-item">
@@ -90,6 +93,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>
                         <li><a href="contact.html">Contact</a></li>


### PR DESCRIPTION
### Motivation
- Provide a tiny, zero-registration poster generator that converts text into centered social-media posters and exports PNGs quickly.
- Keep the tool extremely simple and reliable (single-page workflow, preset sizes, single-font layout).
- Surface the new tool from the site by adding navigation links and sitemap entries for discoverability.

### Description
- Add a new page `poster-generator.html` containing the UI: text input, preset size selector, font and background controls, live canvas preview, and the `Export PNG` button.
- Implement rendering and export logic in `poster.js` using Canvas API with presets for WeChat, Instagram, X, and Pinterest and filename format `poster-{width}x{height}.png`.
- Add poster-specific styles to `styles.css` to support the two-column layout, responsive behavior, preview canvas styling, and meta display.
- Update site navigation and footer quick links across multiple pages and update `sitemap.html` and `sitemap.xml` to include the new tool.

### Testing
- Started a local HTTP server with `python -m http.server` to serve the site (server started successfully).
- Attempted an automated visual check via Playwright to capture `poster-generator.html`, but Chromium crashed and the Playwright run failed.
- No other automated unit or integration tests were executed for these static frontend changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be4a954748321a1ba070076da040b)