### PR TITLE
Add text color picker and auto-contrast toggle to poster generator

### DIFF
--- a/poster-generator.html
+++ b/poster-generator.html
@@ -137,6 +137,19 @@
                             <div class="poster-size-pill" id="posterSizeLabel">1080 × 1920</div>
                         </div>
                     </div>
+                    <div class="poster-form-row">
+                        <div class="form-group">
+                            <label for="posterTextColor">Text Color</label>
+                            <input type="color" id="posterTextColor" value="#111827">
+                        </div>
+                        <div class="form-group">
+                            <label>Auto Contrast</label>
+                            <label class="checkbox-label" for="posterAutoColor">
+                                <input type="checkbox" id="posterAutoColor" checked>
+                                <span>Match background readability</span>
+                            </label>
+                        </div>
+                    </div>
                     <div class="form-actions">
                         <button class="btn btn-primary" id="posterExportBtn" type="button">
                             <i class="fas fa-download"></i>
@@ -153,6 +166,7 @@
                         <li><i class="fas fa-expand"></i><span id="posterMetaSize">1080 × 1920 px</span></li>
                         <li><i class="fas fa-font"></i><span id="posterMetaFont">Inter</span></li>
                         <li><i class="fas fa-palette"></i><span id="posterMetaBg">#FFFFFF</span></li>
+                        <li><i class="fas fa-pen-nib"></i><span id="posterMetaText">#111827</span></li>
                     </ul>
                 </div>
             </div>

--- a/poster.js
+++ b/poster.js
@@ -10,10 +10,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const sizeSelect = document.getElementById('posterSize');
     const fontSelect = document.getElementById('posterFont');
     const backgroundInput = document.getElementById('posterBackground');
+    const textColorInput = document.getElementById('posterTextColor');
+    const autoColorToggle = document.getElementById('posterAutoColor');
     const sizeLabel = document.getElementById('posterSizeLabel');
     const metaSize = document.getElementById('posterMetaSize');
     const metaFont = document.getElementById('posterMetaFont');
     const metaBg = document.getElementById('posterMetaBg');
+    const metaText = document.getElementById('posterMetaText');
     const exportBtn = document.getElementById('posterExportBtn');
     const canvas = document.getElementById('posterCanvas');
 
@@ -23,12 +26,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const ctx = canvas.getContext('2d');
 
-    const updateMeta = (preset) => {
+    const updateMeta = (preset, textColor) => {
         const sizeText = `${preset.width} × ${preset.height}`;
         sizeLabel.textContent = sizeText;
         metaSize.textContent = `${sizeText} px`;
         metaFont.textContent = fontSelect.options[fontSelect.selectedIndex].textContent;
         metaBg.textContent = backgroundInput.value.toUpperCase();
+        metaText.textContent = textColor.toUpperCase();
     };
 
     const getLines = () => {
@@ -95,7 +99,14 @@ document.addEventListener('DOMContentLoaded', () => {
         titleSize = Math.round(titleSize * scale);
         subtitleSize = Math.round(subtitleSize * scale);
 
-        const textColor = getTextColor(backgroundInput.value);
+        const autoTextColor = getTextColor(backgroundInput.value);
+        const textColor = autoColorToggle && autoColorToggle.checked ? autoTextColor : textColorInput.value;
+        if (autoColorToggle && autoColorToggle.checked) {
+            textColorInput.value = autoTextColor;
+            textColorInput.disabled = true;
+        } else if (textColorInput) {
+            textColorInput.disabled = false;
+        }
         ctx.fillStyle = textColor;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';
@@ -115,7 +126,7 @@ document.addEventListener('DOMContentLoaded', () => {
             currentY += subtitleSize * 1.2 + lineGap;
         });
 
-        updateMeta(preset);
+        updateMeta(preset, textColor);
     };
 
     const handleChange = () => {
@@ -152,6 +163,12 @@ document.addEventListener('DOMContentLoaded', () => {
     sizeSelect.addEventListener('change', handleChange);
     fontSelect.addEventListener('change', handleChange);
     backgroundInput.addEventListener('input', handleChange);
+    if (textColorInput) {
+        textColorInput.addEventListener('input', handleChange);
+    }
+    if (autoColorToggle) {
+        autoColorToggle.addEventListener('change', handleChange);
+    }
     exportBtn.addEventListener('click', handleExport);
 
     document.fonts.ready.then(renderPoster);


### PR DESCRIPTION
### Motivation
- Provide a manual text color control so users can override the automatic contrast choice.  
- Preserve automatic readability by offering an auto-contrast toggle that picks a high-contrast color against the background.  
- Surface the chosen text color in the poster metadata panel for clarity.  
- Keep poster export behavior unchanged while making color controls discoverable and editable.

### Description
- Added a text color picker `#posterTextColor` and an auto-contrast checkbox `#posterAutoColor` to `poster-generator.html`.  
- Exposed the selected text color in the metadata list via a new `#posterMetaText` element.  
- Wired UI into `poster.js`: compute automatic color with the existing `getTextColor` helper, honor manual overrides, disable the color input when auto mode is enabled, and call `updateMeta(preset, textColor)` to update metadata.  
- Hooked change listeners for `#posterTextColor` and `#posterAutoColor` so the poster preview re-renders on user interaction.

### Testing
- Started a local static server with `python -m http.server` to serve the site (server startup succeeded).  
- Ran a Playwright script to capture a visual snapshot of the updated page which produced a screenshot artifact (succeeded).  
- An earlier Playwright attempt to fill the text input timed out waiting for the locator (that attempt failed), but subsequent DOM snapshot confirmed the UI changes were present.  
- No automated unit tests exist for the static UI; the change is limited to static site JS/HTML updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694befbd361083218f5d2bcf0b6b8a3d)