### PR TITLE
Add watermark remover page with crop/cover (blur/solid) tools

### DIFF
--- a/about.html
+++ b/about.html
@@ -24,6 +24,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="watermark-remover.html" class="nav-link">Watermark Remover</a>
+                </li>
+                <li class="nav-item">
                     <a href="poster-generator.html" class="nav-link">Poster Generator</a>
                 </li>
                 <li class="nav-item">
@@ -90,6 +93,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="watermark-remover.html">Watermark Remover</a></li>
                         <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>

--- a/contact.html
+++ b/contact.html
@@ -24,6 +24,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="watermark-remover.html" class="nav-link">Watermark Remover</a>
+                </li>
+                <li class="nav-item">
                     <a href="poster-generator.html" class="nav-link">Poster Generator</a>
                 </li>
                 <li class="nav-item">
@@ -231,6 +234,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="watermark-remover.html">Watermark Remover</a></li>
                         <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>

--- a/faq.html
+++ b/faq.html
@@ -119,6 +119,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="watermark-remover.html" class="nav-link">Watermark Remover</a>
+                </li>
+                <li class="nav-item">
                     <a href="poster-generator.html" class="nav-link">Poster Generator</a>
                 </li>
                 <li class="nav-item">
@@ -362,6 +365,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="watermark-remover.html">Watermark Remover</a></li>
                         <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>

--- a/features.html
+++ b/features.html
@@ -24,6 +24,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="watermark-remover.html" class="nav-link">Watermark Remover</a>
+                </li>
+                <li class="nav-item">
                     <a href="poster-generator.html" class="nav-link">Poster Generator</a>
                 </li>
                 <li class="nav-item">
@@ -269,6 +272,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="watermark-remover.html">Watermark Remover</a></li>
                         <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>

--- a/index.html
+++ b/index.html
@@ -205,6 +205,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="watermark-remover.html" class="nav-link">Watermark Remover</a>
+                </li>
+                <li class="nav-item">
                     <a href="poster-generator.html" class="nav-link">Poster Generator</a>
                 </li>
                 <li class="nav-item">
@@ -518,6 +521,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="watermark-remover.html">Watermark Remover</a></li>
                         <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>

--- a/poster-generator.html
+++ b/poster-generator.html
@@ -55,6 +55,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="watermark-remover.html" class="nav-link">Watermark Remover</a>
+                </li>
+                <li class="nav-item">
                     <a href="poster-generator.html" class="nav-link active">Poster Generator</a>
                 </li>
                 <li class="nav-item">
@@ -250,6 +253,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="watermark-remover.html">Watermark Remover</a></li>
                         <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -24,6 +24,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="watermark-remover.html" class="nav-link">Watermark Remover</a>
+                </li>
+                <li class="nav-item">
                     <a href="poster-generator.html" class="nav-link">Poster Generator</a>
                 </li>
                 <li class="nav-item">
@@ -95,6 +98,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="watermark-remover.html">Watermark Remover</a></li>
                         <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>

--- a/sitemap.html
+++ b/sitemap.html
@@ -84,6 +84,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="watermark-remover.html" class="nav-link">Watermark Remover</a>
+                </li>
+                <li class="nav-item">
                     <a href="poster-generator.html" class="nav-link">Poster Generator</a>
                 </li>
                 <li class="nav-item">
@@ -136,6 +139,7 @@
                     <ul class="sitemap-links">
                         <li><a href="index.html">Home - Free Image Resizer Online</a></li>
                         <li><a href="resizer.html">Image Resizer - Resize Images Without Losing Quality</a></li>
+                        <li><a href="watermark-remover.html">Watermark Remover - Crop or Cover Watermarks</a></li>
                         <li><a href="poster-generator.html">Minimal Poster Generator - Create Clean Social Media Posters</a></li>
                         <li><a href="about.html">About Us - Learn About TopicPicture</a></li>
                         <li><a href="features.html">Features - Image Resizer Tool Capabilities</a></li>
@@ -150,6 +154,7 @@
                     <h2><i class="fas fa-tools"></i> Image Resizer Tools</h2>
                     <ul class="sitemap-links">
                         <li><a href="resizer.html">Online Image Resizer Tool</a></li>
+                        <li><a href="watermark-remover.html">Watermark Remover (Crop/Blur)</a></li>
                         <li><a href="resize-jpeg-online.html">Resize JPEG Images Online</a></li>
                         <li><a href="resize-png-online.html">Resize PNG Images Online</a></li>
                         <li><a href="compress-image-online.html">Compress Images Online</a></li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -20,6 +20,12 @@
         <priority>0.9</priority>
     </url>
     <url>
+        <loc>https://topicture.online/watermark-remover.html</loc>
+        <lastmod>2024-12-20</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.9</priority>
+    </url>
+    <url>
         <loc>https://topicture.online/poster-generator.html</loc>
         <lastmod>2024-12-20</lastmod>
         <changefreq>weekly</changefreq>

--- a/styles.css
+++ b/styles.css
@@ -440,6 +440,104 @@ body {
     align-items: start;
 }
 
+/* Watermark Remover */
+.watermark-section .resizer-controls {
+    grid-template-columns: 1.2fr 0.8fr;
+}
+
+.watermark-preview {
+    position: relative;
+}
+
+.watermark-canvas-wrap {
+    width: 100%;
+    background: white;
+    border-radius: var(--border-radius);
+    overflow: hidden;
+    box-shadow: var(--shadow);
+}
+
+.watermark-canvas-wrap canvas {
+    width: 100%;
+    height: auto;
+    display: block;
+    cursor: crosshair;
+}
+
+.watermark-info {
+    margin-top: 1rem;
+    gap: 1rem;
+}
+
+.toggle-group {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.toggle-btn {
+    border: 2px solid var(--border-color);
+    background: white;
+    color: var(--text-secondary);
+    padding: 0.5rem 1.25rem;
+    border-radius: 999px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.toggle-btn.active {
+    background: var(--primary-color);
+    border-color: var(--primary-color);
+    color: white;
+}
+
+.toggle-btn:hover {
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+}
+
+.cover-color-row {
+    margin-top: 0.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.cover-color-row input[type=\"color\"] {
+    width: 64px;
+    height: 40px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+}
+
+.output-preview {
+    margin-top: 2rem;
+    background: white;
+    border-radius: var(--border-radius);
+    padding: 1rem;
+    box-shadow: var(--shadow);
+    text-align: center;
+}
+
+.output-preview img {
+    max-width: 100%;
+    border-radius: var(--border-radius);
+    margin-top: 0.75rem;
+}
+
+.disclaimer {
+    margin-top: 1.5rem;
+    padding: 1rem;
+    background: rgba(99, 102, 241, 0.08);
+    border-radius: var(--border-radius);
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    border: 1px solid rgba(99, 102, 241, 0.2);
+}
+
 .image-preview-container {
     background: var(--background-alt);
     border-radius: var(--border-radius-lg);

--- a/terms.html
+++ b/terms.html
@@ -24,6 +24,9 @@
                     <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
+                    <a href="watermark-remover.html" class="nav-link">Watermark Remover</a>
+                </li>
+                <li class="nav-item">
                     <a href="poster-generator.html" class="nav-link">Poster Generator</a>
                 </li>
                 <li class="nav-item">
@@ -93,6 +96,7 @@
                     <ul>
                         <li><a href="index.html">Home</a></li>
                         <li><a href="resizer.html">Image Resizer</a></li>
+                        <li><a href="watermark-remover.html">Watermark Remover</a></li>
                         <li><a href="poster-generator.html">Poster Generator</a></li>
                         <li><a href="about.html">About</a></li>
                         <li><a href="features.html">Features</a></li>

--- a/watermark-remover.html
+++ b/watermark-remover.html
@@ -3,10 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Online Image Resizer Tool - Resize Images Without Losing Quality</title>
-    <meta name="description" content="Resize images online without losing quality. Upload a JPG, PNG, GIF, or WebP file, set your dimensions, and download a crisp resized image instantly.">
-    <meta name="keywords" content="online image resizer, resize images without losing quality, resize photo online, resize jpeg, resize png, resize webp, image size reducer">
-    <link rel="canonical" href="https://topicture.online/resizer.html">
+    <title>Remove Watermark (Crop) – Free Online Tool</title>
+    <meta name="description" content="Remove watermarks by cropping or covering areas for images you own or have permission to edit. Export PNG, JPG, or WebP locally with no signup.">
+    <meta name="keywords" content="remove watermark, crop watermark, watermark remover, cover watermark, blur watermark, image crop tool">
+    <link rel="canonical" href="https://topicture.online/watermark-remover.html">
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
@@ -24,10 +24,10 @@
                     <a href="index.html" class="nav-link">Home</a>
                 </li>
                 <li class="nav-item">
-                    <a href="resizer.html" class="nav-link active">Image Resizer</a>
+                    <a href="resizer.html" class="nav-link">Image Resizer</a>
                 </li>
                 <li class="nav-item">
-                    <a href="watermark-remover.html" class="nav-link">Watermark Remover</a>
+                    <a href="watermark-remover.html" class="nav-link active">Watermark Remover</a>
                 </li>
                 <li class="nav-item">
                     <a href="poster-generator.html" class="nav-link">Poster Generator</a>
@@ -56,93 +56,122 @@
     <!-- Hero Section -->
     <section class="page-hero">
         <div class="container">
-            <h1>Online Image Resizer Tool</h1>
-            <p>Resize images without losing quality. Adjust dimensions, choose output format, and download instantly.</p>
+            <h1>Remove Watermark (Crop) – Free Online Tool</h1>
+            <p>Remove watermarks by cropping or covering areas for images you own or have permission to edit.</p>
         </div>
     </section>
 
     <section class="info-section alt">
         <div class="container">
-            <h2 class="section-title">Resize Images in Three Simple Steps</h2>
+            <h2 class="section-title">Fast, Private, and Safe</h2>
             <ul class="info-benefits">
-                <li>Upload a JPG, PNG, GIF, or WebP image directly from your device.</li>
-                <li>Set new dimensions or keep the aspect ratio for perfect proportions.</li>
-                <li>Download the resized image with preserved clarity and control over quality.</li>
+                <li>Free to use with no signup or upload required.</li>
+                <li>Runs locally in your browser to protect privacy.</li>
+                <li>Export in PNG, JPG, or WebP with adjustable quality.</li>
             </ul>
         </div>
     </section>
 
-    <!-- Image Resizer Tool -->
-    <section class="resizer-section" id="resizer">
+    <!-- Watermark Remover Tool -->
+    <section class="resizer-section watermark-section" id="watermark-remover">
         <div class="container">
-            <h2 class="section-title">Online Image Resizer Tool - Resize Images Without Losing Quality</h2>
+            <h2 class="section-title">Crop or Cover a Watermark in Seconds</h2>
             <div class="resizer-container">
-                <div class="upload-area" id="uploadArea">
+                <div class="upload-area" id="watermarkUploadArea">
                     <div class="upload-content">
                         <i class="fas fa-cloud-upload-alt"></i>
                         <h3>Drop your image here or click to browse</h3>
-                        <p>Supports JPG, PNG, GIF, WebP formats - Resize JPEG image online, resize PNG online, compress image online</p>
-                        <input type="file" id="imageInput" accept="image/*" hidden>
+                        <p>Supports JPG, PNG, WebP formats. Edit only images you own or have permission to use.</p>
+                        <input type="file" id="watermarkImageInput" accept="image/*" hidden>
                     </div>
                 </div>
 
-                <div class="resizer-controls" id="resizerControls" style="display: none;">
-                    <div class="image-preview-container">
-                        <div class="image-preview" id="imagePreview">
-                            <img id="previewImage" alt="Preview">
+                <div class="resizer-controls watermark-controls" id="watermarkControls" style="display: none;">
+                    <div class="image-preview-container watermark-preview">
+                        <div class="watermark-canvas-wrap">
+                            <canvas id="watermarkCanvas"></canvas>
                         </div>
-                        <div class="image-info">
-                            <span id="originalSize"></span>
-                            <span id="newSize"></span>
+                        <div class="image-info watermark-info">
+                            <span id="watermarkOriginalSize"></span>
+                            <span id="watermarkSelectionSize">Selection: --</span>
                         </div>
                     </div>
 
                     <div class="controls-panel">
                         <div class="control-group">
-                            <label for="widthInput">Width (px)</label>
-                            <input type="number" id="widthInput" min="1" max="10000">
+                            <label>Mode</label>
+                            <div class="toggle-group" role="group" aria-label="Mode">
+                                <button class="toggle-btn active" type="button" data-mode="crop">Crop</button>
+                                <button class="toggle-btn" type="button" data-mode="cover">Cover/Blur</button>
+                            </div>
                         </div>
 
                         <div class="control-group">
-                            <label for="heightInput">Height (px)</label>
-                            <input type="number" id="heightInput" min="1" max="10000">
-                        </div>
-
-                        <div class="control-group">
-                            <label for="aspectRatio">
-                                <input type="checkbox" id="aspectRatio" checked>
+                            <label for="watermarkAspectRatio">
+                                <input type="checkbox" id="watermarkAspectRatio">
                                 Maintain Aspect Ratio
                             </label>
+                            <select id="watermarkRatioSelect">
+                                <option value="free">Free</option>
+                                <option value="original">Original</option>
+                                <option value="1:1">1:1</option>
+                                <option value="4:3">4:3</option>
+                                <option value="16:9">16:9</option>
+                            </select>
+                        </div>
+
+                        <div class="control-group" id="coverOptions" style="display: none;">
+                            <label for="coverType">Cover Style</label>
+                            <select id="coverType">
+                                <option value="blur">Blur Area</option>
+                                <option value="solid">Solid Color</option>
+                            </select>
+                            <div class="cover-color-row">
+                                <label for="coverColor">Cover Color</label>
+                                <input type="color" id="coverColor" value="#f8fafc">
+                            </div>
                         </div>
 
                         <div class="control-group">
-                            <label for="qualitySlider">Quality: <span id="qualityValue">90</span>%</label>
-                            <input type="range" id="qualitySlider" min="10" max="100" value="90">
+                            <label for="watermarkQuality">Quality: <span id="watermarkQualityValue">90</span>%</label>
+                            <input type="range" id="watermarkQuality" min="60" max="100" value="90">
                         </div>
 
                         <div class="control-group">
-                            <label for="formatSelect">Output Format</label>
-                            <select id="formatSelect">
-                                <option value="original">Keep Original</option>
-                                <option value="jpeg">JPEG</option>
+                            <label for="watermarkFormat">Output Format</label>
+                            <select id="watermarkFormat">
                                 <option value="png">PNG</option>
+                                <option value="jpeg">JPG</option>
                                 <option value="webp">WebP</option>
                             </select>
                         </div>
 
                         <div class="action-buttons">
-                            <button class="btn btn-primary" id="resizeBtn">
-                                <i class="fas fa-magic"></i>
-                                Resize Image
+                            <button class="btn btn-primary" id="watermarkExportBtn">
+                                <i class="fas fa-crop-alt"></i>
+                                Export
                             </button>
-                            <button class="btn btn-secondary" id="downloadBtn" disabled>
+                            <button class="btn btn-secondary" id="watermarkDownloadBtn" disabled>
                                 <i class="fas fa-download"></i>
                                 Download
                             </button>
-                            <button class="btn btn-outline" id="resetBtn">
+                            <button class="btn btn-outline" id="watermarkClearBtn">
+                                <i class="fas fa-eraser"></i>
+                                Clear Selection
+                            </button>
+                            <button class="btn btn-outline" id="watermarkResetBtn">
                                 <i class="fas fa-refresh"></i>
                                 Reset
                             </button>
+                        </div>
+
+                        <div class="output-preview" id="watermarkOutputPreview" style="display: none;">
+                            <h4>Output Preview</h4>
+                            <img id="watermarkOutputImage" alt="Output preview">
+                        </div>
+
+                        <div class="disclaimer">
+                            <strong>Disclaimer:</strong> This tool only edits images you own or have permission to modify.
                         </div>
                     </div>
                 </div>
@@ -152,11 +181,11 @@
 
     <section class="info-section">
         <div class="container">
-            <h2 class="section-title">Why Use This Image Resizer?</h2>
+            <h2 class="section-title">Why This Watermark Remover?</h2>
             <ul class="info-benefits">
-                <li>Local processing keeps your images private and secure.</li>
-                <li>Precision controls for width, height, and output quality.</li>
-                <li>Fast results for web, social media, and email-ready images.</li>
+                <li>Simple crop or cover workflows—no AI reconstruction.</li>
+                <li>Fast export with full control over format and quality.</li>
+                <li>Works on desktop and mobile with drag-and-drop support.</li>
             </ul>
         </div>
     </section>
@@ -213,6 +242,6 @@
         </div>
     </footer>
 
-    <script src="script.js"></script>
+    <script src="watermark-remover.js"></script>
 </body>
 </html>

--- a/watermark-remover.js
+++ b/watermark-remover.js
@@ -1,0 +1,432 @@
+let watermarkImage = null;
+let watermarkSelection = null;
+let isDragging = false;
+let isMoving = false;
+let dragStart = { x: 0, y: 0 };
+let selectionOffset = { x: 0, y: 0 };
+let outputDataUrl = null;
+let activeMode = 'crop';
+
+const state = {
+    ratioLocked: false,
+    ratioValue: 'free',
+    quality: 0.9,
+    coverType: 'blur',
+    coverColor: '#f8fafc',
+};
+
+const elements = {};
+
+document.addEventListener('DOMContentLoaded', () => {
+    cacheElements();
+    setupNavigation();
+    setupUpload();
+    setupControls();
+});
+
+function cacheElements() {
+    elements.uploadArea = document.getElementById('watermarkUploadArea');
+    elements.imageInput = document.getElementById('watermarkImageInput');
+    elements.controls = document.getElementById('watermarkControls');
+    elements.canvas = document.getElementById('watermarkCanvas');
+    elements.originalSize = document.getElementById('watermarkOriginalSize');
+    elements.selectionSize = document.getElementById('watermarkSelectionSize');
+    elements.aspectRatio = document.getElementById('watermarkAspectRatio');
+    elements.ratioSelect = document.getElementById('watermarkRatioSelect');
+    elements.modeButtons = document.querySelectorAll('.toggle-btn');
+    elements.coverOptions = document.getElementById('coverOptions');
+    elements.coverType = document.getElementById('coverType');
+    elements.coverColor = document.getElementById('coverColor');
+    elements.quality = document.getElementById('watermarkQuality');
+    elements.qualityValue = document.getElementById('watermarkQualityValue');
+    elements.format = document.getElementById('watermarkFormat');
+    elements.exportBtn = document.getElementById('watermarkExportBtn');
+    elements.downloadBtn = document.getElementById('watermarkDownloadBtn');
+    elements.clearBtn = document.getElementById('watermarkClearBtn');
+    elements.resetBtn = document.getElementById('watermarkResetBtn');
+    elements.outputPreview = document.getElementById('watermarkOutputPreview');
+    elements.outputImage = document.getElementById('watermarkOutputImage');
+    elements.hamburger = document.querySelector('.hamburger');
+    elements.navMenu = document.querySelector('.nav-menu');
+}
+
+function setupNavigation() {
+    if (!elements.hamburger || !elements.navMenu) return;
+    elements.hamburger.addEventListener('click', () => {
+        elements.navMenu.classList.toggle('active');
+        elements.hamburger.classList.toggle('active');
+    });
+    document.querySelectorAll('.nav-link').forEach(link => {
+        link.addEventListener('click', () => {
+            elements.navMenu.classList.remove('active');
+            elements.hamburger.classList.remove('active');
+        });
+    });
+}
+
+function setupUpload() {
+    if (!elements.uploadArea || !elements.imageInput) return;
+    elements.uploadArea.addEventListener('click', () => elements.imageInput.click());
+    elements.uploadArea.addEventListener('dragover', handleDragOver);
+    elements.uploadArea.addEventListener('dragleave', handleDragLeave);
+    elements.uploadArea.addEventListener('drop', handleDrop);
+    elements.imageInput.addEventListener('change', handleFileSelect);
+}
+
+function setupControls() {
+    elements.canvas.addEventListener('mousedown', handlePointerDown);
+    elements.canvas.addEventListener('mousemove', handlePointerMove);
+    elements.canvas.addEventListener('mouseup', handlePointerUp);
+    elements.canvas.addEventListener('mouseleave', handlePointerUp);
+
+    elements.canvas.addEventListener('touchstart', handleTouchStart, { passive: false });
+    elements.canvas.addEventListener('touchmove', handleTouchMove, { passive: false });
+    elements.canvas.addEventListener('touchend', handlePointerUp);
+
+    elements.aspectRatio.addEventListener('change', () => {
+        state.ratioLocked = elements.aspectRatio.checked;
+    });
+
+    elements.ratioSelect.addEventListener('change', () => {
+        state.ratioValue = elements.ratioSelect.value;
+    });
+
+    elements.modeButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            elements.modeButtons.forEach(btn => btn.classList.remove('active'));
+            button.classList.add('active');
+            activeMode = button.dataset.mode;
+            elements.coverOptions.style.display = activeMode === 'cover' ? 'block' : 'none';
+        });
+    });
+
+    elements.coverType.addEventListener('change', () => {
+        state.coverType = elements.coverType.value;
+    });
+
+    elements.coverColor.addEventListener('input', () => {
+        state.coverColor = elements.coverColor.value;
+    });
+
+    elements.quality.addEventListener('input', () => {
+        state.quality = Number(elements.quality.value) / 100;
+        elements.qualityValue.textContent = elements.quality.value;
+    });
+
+    elements.exportBtn.addEventListener('click', exportImage);
+    elements.downloadBtn.addEventListener('click', downloadImage);
+    elements.clearBtn.addEventListener('click', clearSelection);
+    elements.resetBtn.addEventListener('click', resetAll);
+}
+
+function handleDragOver(event) {
+    event.preventDefault();
+    elements.uploadArea.classList.add('dragover');
+}
+
+function handleDragLeave(event) {
+    event.preventDefault();
+    elements.uploadArea.classList.remove('dragover');
+}
+
+function handleDrop(event) {
+    event.preventDefault();
+    elements.uploadArea.classList.remove('dragover');
+    const file = event.dataTransfer.files[0];
+    if (file) processFile(file);
+}
+
+function handleFileSelect(event) {
+    const file = event.target.files[0];
+    if (file) processFile(file);
+}
+
+function processFile(file) {
+    if (!file.type.startsWith('image/')) {
+        alert('Please select a valid image file.');
+        return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = event => loadImage(event.target.result);
+    reader.readAsDataURL(file);
+}
+
+function loadImage(src) {
+    const img = new Image();
+    img.onload = () => {
+        watermarkImage = img;
+        setupCanvas();
+        elements.controls.style.display = 'grid';
+        elements.originalSize.textContent = `Original: ${img.width} × ${img.height}px`;
+        elements.selectionSize.textContent = 'Selection: --';
+        elements.outputPreview.style.display = 'none';
+        elements.downloadBtn.disabled = true;
+        outputDataUrl = null;
+        watermarkSelection = null;
+        renderCanvas();
+    };
+    img.src = src;
+}
+
+function setupCanvas() {
+    elements.canvas.width = watermarkImage.width;
+    elements.canvas.height = watermarkImage.height;
+}
+
+function handlePointerDown(event) {
+    if (!watermarkImage) return;
+    const { x, y } = getCanvasPoint(event);
+
+    if (watermarkSelection && pointInSelection(x, y)) {
+        isMoving = true;
+        selectionOffset = { x: x - watermarkSelection.x, y: y - watermarkSelection.y };
+        return;
+    }
+
+    isDragging = true;
+    dragStart = { x, y };
+    watermarkSelection = { x, y, width: 0, height: 0 };
+}
+
+function handlePointerMove(event) {
+    if (!watermarkImage) return;
+
+    const { x, y } = getCanvasPoint(event);
+
+    if (isDragging) {
+        updateSelectionFromDrag(x, y);
+        renderCanvas();
+    } else if (isMoving) {
+        const newX = clamp(x - selectionOffset.x, 0, watermarkImage.width - watermarkSelection.width);
+        const newY = clamp(y - selectionOffset.y, 0, watermarkImage.height - watermarkSelection.height);
+        watermarkSelection.x = newX;
+        watermarkSelection.y = newY;
+        renderCanvas();
+    }
+}
+
+function handlePointerUp() {
+    if (isDragging) {
+        finalizeSelection();
+    }
+    isDragging = false;
+    isMoving = false;
+}
+
+function handleTouchStart(event) {
+    event.preventDefault();
+    handlePointerDown(event.touches[0]);
+}
+
+function handleTouchMove(event) {
+    event.preventDefault();
+    handlePointerMove(event.touches[0]);
+}
+
+function updateSelectionFromDrag(x, y) {
+    let width = x - dragStart.x;
+    let height = y - dragStart.y;
+
+    if (state.ratioLocked && state.ratioValue !== 'free') {
+        const ratio = getRatioValue();
+        if (Math.abs(width) > Math.abs(height)) {
+            height = Math.abs(width) / ratio * Math.sign(height || 1);
+        } else {
+            width = Math.abs(height) * ratio * Math.sign(width || 1);
+        }
+    }
+
+    watermarkSelection = {
+        x: dragStart.x,
+        y: dragStart.y,
+        width,
+        height,
+    };
+}
+
+function finalizeSelection() {
+    if (!watermarkSelection) return;
+    const normalized = normalizeSelection(watermarkSelection);
+    if (normalized.width < 5 || normalized.height < 5) {
+        watermarkSelection = null;
+        elements.selectionSize.textContent = 'Selection: --';
+        renderCanvas();
+        return;
+    }
+    watermarkSelection = normalized;
+    updateSelectionText();
+    renderCanvas();
+}
+
+function normalizeSelection(selection) {
+    const width = Math.abs(selection.width);
+    const height = Math.abs(selection.height);
+    const x = selection.width < 0 ? selection.x - width : selection.x;
+    const y = selection.height < 0 ? selection.y - height : selection.y;
+
+    const clampedX = clamp(x, 0, watermarkImage.width - width);
+    const clampedY = clamp(y, 0, watermarkImage.height - height);
+
+    return { x: clampedX, y: clampedY, width, height };
+}
+
+function updateSelectionText() {
+    if (!watermarkSelection) {
+        elements.selectionSize.textContent = 'Selection: --';
+        return;
+    }
+    elements.selectionSize.textContent = `Selection: ${Math.round(watermarkSelection.width)} × ${Math.round(watermarkSelection.height)}px`;
+}
+
+function renderCanvas() {
+    if (!watermarkImage) return;
+    const ctx = elements.canvas.getContext('2d');
+    ctx.clearRect(0, 0, elements.canvas.width, elements.canvas.height);
+    ctx.drawImage(watermarkImage, 0, 0);
+
+    if (watermarkSelection) {
+        ctx.fillStyle = 'rgba(15, 23, 42, 0.5)';
+        ctx.fillRect(0, 0, elements.canvas.width, elements.canvas.height);
+        ctx.drawImage(
+            watermarkImage,
+            watermarkSelection.x,
+            watermarkSelection.y,
+            watermarkSelection.width,
+            watermarkSelection.height,
+            watermarkSelection.x,
+            watermarkSelection.y,
+            watermarkSelection.width,
+            watermarkSelection.height
+        );
+        ctx.strokeStyle = '#10b981';
+        ctx.lineWidth = 3;
+        ctx.strokeRect(
+            watermarkSelection.x + 1.5,
+            watermarkSelection.y + 1.5,
+            watermarkSelection.width - 3,
+            watermarkSelection.height - 3
+        );
+    }
+}
+
+function exportImage() {
+    if (!watermarkImage || !watermarkSelection) {
+        alert('Please draw a selection before exporting.');
+        return;
+    }
+
+    const format = elements.format.value;
+    let canvas = document.createElement('canvas');
+    let ctx = canvas.getContext('2d');
+
+    if (activeMode === 'crop') {
+        canvas.width = watermarkSelection.width;
+        canvas.height = watermarkSelection.height;
+        ctx.drawImage(
+            watermarkImage,
+            watermarkSelection.x,
+            watermarkSelection.y,
+            watermarkSelection.width,
+            watermarkSelection.height,
+            0,
+            0,
+            watermarkSelection.width,
+            watermarkSelection.height
+        );
+    } else {
+        canvas.width = watermarkImage.width;
+        canvas.height = watermarkImage.height;
+        ctx.drawImage(watermarkImage, 0, 0);
+        if (state.coverType === 'blur') {
+            ctx.save();
+            ctx.filter = 'blur(8px)';
+            ctx.drawImage(
+                watermarkImage,
+                watermarkSelection.x,
+                watermarkSelection.y,
+                watermarkSelection.width,
+                watermarkSelection.height,
+                watermarkSelection.x,
+                watermarkSelection.y,
+                watermarkSelection.width,
+                watermarkSelection.height
+            );
+            ctx.restore();
+        } else {
+            ctx.fillStyle = state.coverColor;
+            ctx.fillRect(
+                watermarkSelection.x,
+                watermarkSelection.y,
+                watermarkSelection.width,
+                watermarkSelection.height
+            );
+        }
+    }
+
+    const mimeType = format === 'png' ? 'image/png' : `image/${format}`;
+    outputDataUrl = canvas.toDataURL(mimeType, state.quality);
+    elements.outputImage.src = outputDataUrl;
+    elements.outputPreview.style.display = 'block';
+    elements.downloadBtn.disabled = false;
+}
+
+function downloadImage() {
+    if (!outputDataUrl) return;
+    const format = elements.format.value;
+    const link = document.createElement('a');
+    link.href = outputDataUrl;
+    link.download = `watermark-${activeMode}.${format}`;
+    link.click();
+}
+
+function clearSelection() {
+    watermarkSelection = null;
+    updateSelectionText();
+    renderCanvas();
+}
+
+function resetAll() {
+    watermarkImage = null;
+    watermarkSelection = null;
+    outputDataUrl = null;
+    elements.controls.style.display = 'none';
+    elements.uploadArea.classList.remove('dragover');
+    elements.imageInput.value = '';
+    elements.outputPreview.style.display = 'none';
+    elements.downloadBtn.disabled = true;
+}
+
+function pointInSelection(x, y) {
+    if (!watermarkSelection) return false;
+    return (
+        x >= watermarkSelection.x &&
+        x <= watermarkSelection.x + watermarkSelection.width &&
+        y >= watermarkSelection.y &&
+        y <= watermarkSelection.y + watermarkSelection.height
+    );
+}
+
+function getRatioValue() {
+    if (state.ratioValue === 'original' && watermarkImage) {
+        return watermarkImage.width / watermarkImage.height;
+    }
+    if (state.ratioValue === '1:1') return 1;
+    if (state.ratioValue === '4:3') return 4 / 3;
+    if (state.ratioValue === '16:9') return 16 / 9;
+    return 1;
+}
+
+function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+}
+
+function getCanvasPoint(event) {
+    const rect = elements.canvas.getBoundingClientRect();
+    const scaleX = elements.canvas.width / rect.width;
+    const scaleY = elements.canvas.height / rect.height;
+    return {
+        x: clamp((event.clientX - rect.left) * scaleX, 0, elements.canvas.width),
+        y: clamp((event.clientY - rect.top) * scaleY, 0, elements.canvas.height),
+    };
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, review-friendly watermark removal workflow that operates locally in the browser for privacy and easy approval.
- Offer two safe modes (crop and cover) that let users remove or obscure watermarks on images they own or have permission to edit.
- Make the feature immediately discoverable by integrating it into site navigation, footers, and sitemaps.

### Description
- Add a new page `watermark-remover.html` implementing the UI and copy, including a disclaimer and export options for `PNG/JPG/WebP`.
- Add `watermark-remover.js` which implements canvas-based image loading, rectangular selection (drag/move), crop and cover modes (blur or solid color), export and download logic.
- Update `styles.css` with dedicated styles for the watermark editor (`.watermark-section`, canvas wrapper, toggle buttons, output preview, and disclaimer).
- Wire the new tool into site navigation and footers across existing pages and add it to `sitemap.html` and `sitemap.xml` so the page is discoverable.

### Testing
- Started a local static server with `python -m http.server 8000` and loaded `http://127.0.0.1:8000/watermark-remover.html` to verify the page renders.
- Ran an automated Playwright script to open the page and capture a screenshot, and the screenshot artifact was produced successfully.
- No unit tests were added; automated smoke tests above completed without error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c61b675dc83219bfa1b199832f37b)