### PR TITLE
Move text-to-picture background picker under preview and scope background styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,7 +306,27 @@
                             </select>
                         </div>
                     </div>
-                    <div class="form-group">
+                    <div class="form-actions">
+                        <button class="btn btn-primary" id="textGenerateBtn" type="button">
+                            <i class="fas fa-wand-magic"></i>
+                            Create Picture
+                        </button>
+                        <button class="btn btn-secondary" id="textDownloadBtn" type="button" disabled>
+                            <i class="fas fa-download"></i>
+                            Download Image
+                        </button>
+                    </div>
+                    <p class="form-hint">Tip: Longer prompts with clear visual directions yield richer artwork.</p>
+                </div>
+                <div class="text2picture-preview">
+                    <div class="preview-frame">
+                        <img id="textPreviewImage" alt="Generated from text" loading="lazy">
+                        <div class="preview-placeholder" id="textPreviewPlaceholder">
+                            <i class="fas fa-sparkles"></i>
+                            <p>Your generated image will appear here.</p>
+                        </div>
+                    </div>
+                    <div class="preview-background">
                         <label>Background</label>
                         <div class="background-options" role="radiogroup" aria-label="Background color">
                             <label class="background-option">
@@ -332,26 +352,6 @@
                         </div>
                         <div class="custom-color-picker" id="textBackgroundCustomPicker">
                             <input type="color" id="textBackgroundColor" value="#ffffff" aria-label="Custom background color">
-                        </div>
-                    </div>
-                    <div class="form-actions">
-                        <button class="btn btn-primary" id="textGenerateBtn" type="button">
-                            <i class="fas fa-wand-magic"></i>
-                            Create Picture
-                        </button>
-                        <button class="btn btn-secondary" id="textDownloadBtn" type="button" disabled>
-                            <i class="fas fa-download"></i>
-                            Download Image
-                        </button>
-                    </div>
-                    <p class="form-hint">Tip: Longer prompts with clear visual directions yield richer artwork.</p>
-                </div>
-                <div class="text2picture-preview">
-                    <div class="preview-frame">
-                        <img id="textPreviewImage" alt="Generated from text" loading="lazy">
-                        <div class="preview-placeholder" id="textPreviewPlaceholder">
-                            <i class="fas fa-sparkles"></i>
-                            <p>Your generated image will appear here.</p>
                         </div>
                     </div>
                     <ul class="preview-meta" id="textPreviewMeta">

--- a/styles.css
+++ b/styles.css
@@ -238,9 +238,15 @@ body {
     gap: 1.5rem;
 }
 
-.background-options {
+.text2picture-section .background-options {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.75rem;
+}
+
+.preview-background {
+    display: flex;
+    flex-direction: column;
     gap: 0.75rem;
 }
 
@@ -1973,7 +1979,7 @@ body {
     margin-bottom: 1.5rem;
 }
 
-.background-options {
+.poster-generator-section .background-options {
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;


### PR DESCRIPTION
### Motivation
- The text-to-picture background color picker was placed in the form but the desired UX places it under the preview image for easier previewing.  
- `.background-options` styles conflicted between the text-to-picture controls and the poster generator, causing layout/style collisions.  

### Description
- Moved the text background picker markup from the form into a new `div` under the preview called `preview-background` in `index.html`.  
- Scoped the generic `.background-options` rules to `.text2picture-section .background-options` and `.poster-generator-section .background-options` in `styles.css` to avoid cross-component style leakage.  
- Added a small `.preview-background` CSS block to style the relocated picker.  
- Changes applied to `index.html` and `styles.css`.

### Testing
- A local HTTP server was started with `python -m http.server` as part of a visual smoke test attempt.  
- A Playwright script was executed to capture a screenshot of `#text-to-picture`, but the browser process crashed/timed out and the screenshot attempt failed.  
- No unit or integration tests were run for these static layout changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69508d9b48c48321a9c4bcad2cbcbddb)