### PR TITLE
Remove black and gray background presets

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,16 +335,6 @@
                                 <span>White</span>
                             </label>
                             <label class="background-option">
-                                <input type="radio" name="textBackground" value="black">
-                                <span class="color-swatch swatch-black" aria-hidden="true"></span>
-                                <span>Black</span>
-                            </label>
-                            <label class="background-option">
-                                <input type="radio" name="textBackground" value="gray">
-                                <span class="color-swatch swatch-gray" aria-hidden="true"></span>
-                                <span>Gray</span>
-                            </label>
-                            <label class="background-option">
                                 <input type="radio" name="textBackground" value="custom" id="textBackgroundCustomOption">
                                 <span class="color-swatch swatch-custom" aria-hidden="true"></span>
                                 <span>Custom</span>

--- a/poster-generator.html
+++ b/poster-generator.html
@@ -135,8 +135,6 @@
                             <label>Background</label>
                             <div class="background-options" role="group" aria-label="Background color options">
                                 <button class="bg-option active" type="button" data-color="#ffffff">White</button>
-                                <button class="bg-option" type="button" data-color="#111827">Black</button>
-                                <button class="bg-option" type="button" data-color="#9ca3af">Gray</button>
                                 <div class="bg-custom">
                                     <span>Custom</span>
                                     <input type="color" id="posterBackground" value="#ffffff" aria-label="Custom background color">


### PR DESCRIPTION
### Motivation
- Simplify background choices by removing the Black and Gray presets and keep White as the default option.
- Preserve the ability for users to choose any color via the custom color picker instead of fixed dark presets.
- Reduce UI clutter in the text-to-picture and poster generator sections.

### Description
- Removed the Black and Gray radio options from the text-to-picture background group in `index.html`.
- Removed the Black and Gray preset buttons from the poster generator background options in `poster-generator.html`.
- Kept the White default selection and retained the `custom` color picker for user-defined backgrounds.

### Testing
- Performed a code search with `rg` to locate background option occurrences and confirmed updates applied to `index.html` and `poster-generator.html` successfully.
- Served the site using `python -m http.server 8000` and ran a Playwright script to capture screenshots of the updated UI, which completed successfully and produced `artifacts/index-background-options.png` and `artifacts/poster-background-options.png`.
- Verified repository changes with `git status` and committed the modifications, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695091eb39388321aa3a4ed4590eac42)