### PR TITLE
Simplify text-to-picture background color selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,21 +327,9 @@
                         </div>
                     </div>
                     <div class="preview-background">
-                        <label>Background</label>
-                        <div class="background-options" role="radiogroup" aria-label="Background color">
-                            <label class="background-option">
-                                <input type="radio" name="textBackground" value="white" checked>
-                                <span class="color-swatch swatch-white" aria-hidden="true"></span>
-                                <span>White</span>
-                            </label>
-                            <label class="background-option">
-                                <input type="radio" name="textBackground" value="custom" id="textBackgroundCustomOption">
-                                <span class="color-swatch swatch-custom" aria-hidden="true"></span>
-                                <span>Custom</span>
-                            </label>
-                        </div>
-                        <div class="custom-color-picker" id="textBackgroundCustomPicker">
-                            <input type="color" id="textBackgroundColor" value="#ffffff" aria-label="Custom background color">
+                        <label for="textBackgroundColor">Background Color</label>
+                        <div class="custom-color-picker">
+                            <input type="color" id="textBackgroundColor" value="#ffffff" aria-label="Background color">
                         </div>
                     </div>
                     <ul class="preview-meta" id="textPreviewMeta">

--- a/script.js
+++ b/script.js
@@ -10,7 +10,7 @@ let widthInput, heightInput, aspectRatioCheckbox, qualitySlider, qualityValue;
 let formatSelect, resizeBtn, downloadBtn, resetBtn;
 let promptInput, textWidthInput, textHeightInput, textFormatSelect, textGenerateBtn, textDownloadBtn;
 let textPreviewImage, textPreviewPlaceholder, textPreviewSize, textPreviewFormat;
-let textBackgroundOptions, textBackgroundColor, textBackgroundCustomPicker;
+let textBackgroundColor;
 let hamburger, navMenu;
 
 // Initialize the application
@@ -49,9 +49,7 @@ function initializeDOMElements() {
     textPreviewPlaceholder = document.getElementById('textPreviewPlaceholder');
     textPreviewSize = document.getElementById('textPreviewSize');
     textPreviewFormat = document.getElementById('textPreviewFormat');
-    textBackgroundOptions = document.querySelectorAll('input[name="textBackground"]');
     textBackgroundColor = document.getElementById('textBackgroundColor');
-    textBackgroundCustomPicker = document.getElementById('textBackgroundCustomPicker');
 
     // Debug: Log which elements were found
     console.log('DOM Elements initialized:', {
@@ -79,7 +77,6 @@ function initializeDOMElements() {
         textGenerateBtn: !!textGenerateBtn,
         textDownloadBtn: !!textDownloadBtn,
         textPreviewImage: !!textPreviewImage,
-        textBackgroundOptions: textBackgroundOptions && textBackgroundOptions.length > 0,
         textBackgroundColor: !!textBackgroundColor
     });
 }
@@ -120,16 +117,6 @@ function initializeEventListeners() {
     // Text to picture events
     if (textGenerateBtn) textGenerateBtn.addEventListener('click', generateTextToImage);
     if (textDownloadBtn) textDownloadBtn.addEventListener('click', downloadGeneratedTextImage);
-    if (textBackgroundOptions && textBackgroundOptions.length > 0) {
-        textBackgroundOptions.forEach(option => {
-            option.addEventListener('change', updateBackgroundPickerVisibility);
-        });
-    }
-    if (textBackgroundColor) {
-        textBackgroundColor.addEventListener('input', updateBackgroundPickerVisibility);
-    }
-    updateBackgroundPickerVisibility();
-
     console.log('Event listeners initialized successfully');
 }
 
@@ -347,7 +334,10 @@ function generateTextToImage(event) {
     textGenerateBtn.disabled = true;
 
     const backgroundColor = getSelectedBackgroundColor();
-    const textColors = getTextFillColors(backgroundColor);
+    const textColors = {
+        primary: '#000000',
+        secondary: 'rgba(0, 0, 0, 0.6)'
+    };
     ctx.fillStyle = backgroundColor;
     ctx.fillRect(0, 0, width, height);
 
@@ -456,72 +446,8 @@ function updateTextPreviewMeta(width, height, mimeType) {
     }
 }
 
-function updateBackgroundPickerVisibility() {
-    if (!textBackgroundCustomPicker) return;
-    const selectedOption = getSelectedBackgroundOption();
-    const shouldShow = selectedOption && selectedOption.value === 'custom';
-    textBackgroundCustomPicker.classList.toggle('active', shouldShow);
-}
-
-function getSelectedBackgroundOption() {
-    if (!textBackgroundOptions || textBackgroundOptions.length === 0) {
-        return null;
-    }
-    return Array.from(textBackgroundOptions).find(option => option.checked) || null;
-}
-
 function getSelectedBackgroundColor() {
-    const selectedOption = getSelectedBackgroundOption();
-    if (!selectedOption) {
-        return '#ffffff';
-    }
-    switch (selectedOption.value) {
-        case 'black':
-            return '#111827';
-        case 'gray':
-            return '#9ca3af';
-        case 'custom':
-            return textBackgroundColor?.value || '#ffffff';
-        case 'white':
-        default:
-            return '#ffffff';
-    }
-}
-
-function getTextFillColors(backgroundColor) {
-    const rgb = parseHexColor(backgroundColor);
-    const luminance = rgb ? getLuminance(rgb) : 1;
-    const useLightText = luminance < 0.55;
-    return useLightText
-        ? { primary: 'rgba(255, 255, 255, 0.95)', secondary: 'rgba(255, 255, 255, 0.75)' }
-        : { primary: 'rgba(15, 23, 42, 0.9)', secondary: 'rgba(15, 23, 42, 0.65)' };
-}
-
-function parseHexColor(hex) {
-    if (!hex) return null;
-    const normalized = hex.replace('#', '');
-    if (normalized.length === 3) {
-        const expanded = normalized.split('').map(char => char + char).join('');
-        return hexToRgb(expanded);
-    }
-    if (normalized.length === 6) {
-        return hexToRgb(normalized);
-    }
-    return null;
-}
-
-function hexToRgb(hex) {
-    const intVal = parseInt(hex, 16);
-    if (Number.isNaN(intVal)) return null;
-    return {
-        r: (intVal >> 16) & 255,
-        g: (intVal >> 8) & 255,
-        b: intVal & 255
-    };
-}
-
-function getLuminance({ r, g, b }) {
-    return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+    return textBackgroundColor?.value || '#ffffff';
 }
 
 function wrapPromptText(ctx, text, maxWidth) {

--- a/styles.css
+++ b/styles.css
@@ -298,13 +298,9 @@ body {
 
 .custom-color-picker {
     margin-top: 0.75rem;
-    display: none;
+    display: flex;
     align-items: center;
     gap: 0.5rem;
-}
-
-.custom-color-picker.active {
-    display: flex;
 }
 
 .custom-color-picker input[type="color"] {


### PR DESCRIPTION
### Motivation
- Remove the legacy three-option background control (White / Black / Custom) and provide a simpler single color picker for the text-to-picture feature. 
- Keep the default generated background white and ensure text is rendered in black for consistent contrast. 
- Reduce UI complexity and remove unused background-selection logic to make the feature easier to maintain. 

### Description
- Replaced the background radio group in `index.html` with a single color input `<input type="color" id="textBackgroundColor">` and updated the label to `Background Color`.
- Simplified `script.js` by removing radio option handling, luminance/hex parsing, and dynamic picker visibility, and by defaulting text color to black (`primary: '#000000'`, `secondary: 'rgba(0, 0, 0, 0.6)'`).
- Updated `styles.css` so the color picker (`.custom-color-picker`) is always visible and removed the hidden/active toggle styles.
- Affected files: `index.html`, `script.js`, and `styles.css`.

### Testing
- Started a local static server with `python -m http.server 8000` to preview the changes and the server started successfully. 
- Attempted automated Playwright screenshots to verify the UI twice, but both runs timed out and did not complete (visual check failed due to timeout). 
- No unit tests were added or executed for this change. 
- Manual inspection of modified files was performed (no further automated validation passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950941bc1848321857b4d1b5955a29a)