### PR TITLE
Add background color picker to text-to-picture form and sync preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,6 +305,12 @@
                                 <option value="jpeg">JPEG</option>
                             </select>
                         </div>
+                        <div class="form-group">
+                            <label for="textBackgroundColor">Background Color</label>
+                            <div class="custom-color-picker">
+                                <input type="color" id="textBackgroundColor" value="#ffffff" aria-label="Background color">
+                            </div>
+                        </div>
                     </div>
                     <div class="form-actions">
                         <button class="btn btn-primary" id="textGenerateBtn" type="button">
@@ -319,17 +325,11 @@
                     <p class="form-hint">Tip: Longer prompts with clear visual directions yield richer artwork.</p>
                 </div>
                 <div class="text2picture-preview">
-                    <div class="preview-frame">
+                    <div class="preview-frame" id="textPreviewFrame">
                         <img id="textPreviewImage" alt="Generated from text" loading="lazy">
                         <div class="preview-placeholder" id="textPreviewPlaceholder">
                             <i class="fas fa-sparkles"></i>
                             <p>Your generated image will appear here.</p>
-                        </div>
-                    </div>
-                    <div class="preview-background">
-                        <label for="textBackgroundColor">Background Color</label>
-                        <div class="custom-color-picker">
-                            <input type="color" id="textBackgroundColor" value="#ffffff" aria-label="Background color">
                         </div>
                     </div>
                     <ul class="preview-meta" id="textPreviewMeta">

--- a/script.js
+++ b/script.js
@@ -9,7 +9,7 @@ let uploadArea, imageInput, resizerControls, imagePreview, originalSize, newSize
 let widthInput, heightInput, aspectRatioCheckbox, qualitySlider, qualityValue;
 let formatSelect, resizeBtn, downloadBtn, resetBtn;
 let promptInput, textWidthInput, textHeightInput, textFormatSelect, textGenerateBtn, textDownloadBtn;
-let textPreviewImage, textPreviewPlaceholder, textPreviewSize, textPreviewFormat;
+let textPreviewFrame, textPreviewImage, textPreviewPlaceholder, textPreviewSize, textPreviewFormat;
 let textBackgroundColor;
 let hamburger, navMenu;
 
@@ -45,6 +45,7 @@ function initializeDOMElements() {
     textFormatSelect = document.getElementById('textFormatSelect');
     textGenerateBtn = document.getElementById('textGenerateBtn');
     textDownloadBtn = document.getElementById('textDownloadBtn');
+    textPreviewFrame = document.getElementById('textPreviewFrame');
     textPreviewImage = document.getElementById('textPreviewImage');
     textPreviewPlaceholder = document.getElementById('textPreviewPlaceholder');
     textPreviewSize = document.getElementById('textPreviewSize');
@@ -76,6 +77,7 @@ function initializeDOMElements() {
         textFormatSelect: !!textFormatSelect,
         textGenerateBtn: !!textGenerateBtn,
         textDownloadBtn: !!textDownloadBtn,
+        textPreviewFrame: !!textPreviewFrame,
         textPreviewImage: !!textPreviewImage,
         textBackgroundColor: !!textBackgroundColor
     });
@@ -117,6 +119,10 @@ function initializeEventListeners() {
     // Text to picture events
     if (textGenerateBtn) textGenerateBtn.addEventListener('click', generateTextToImage);
     if (textDownloadBtn) textDownloadBtn.addEventListener('click', downloadGeneratedTextImage);
+    if (textBackgroundColor) {
+        textBackgroundColor.addEventListener('input', updateTextBackgroundPreview);
+        updateTextBackgroundPreview();
+    }
     console.log('Event listeners initialized successfully');
 }
 
@@ -448,6 +454,32 @@ function updateTextPreviewMeta(width, height, mimeType) {
 
 function getSelectedBackgroundColor() {
     return textBackgroundColor?.value || '#ffffff';
+}
+
+function updateTextBackgroundPreview() {
+    if (!textPreviewFrame) return;
+
+    const backgroundColor = getSelectedBackgroundColor();
+    const textColor = getContrastTextColor(backgroundColor);
+    textPreviewFrame.style.setProperty('--preview-bg', backgroundColor);
+    textPreviewFrame.style.setProperty('--preview-text', textColor);
+}
+
+function getContrastTextColor(hexColor) {
+    if (!hexColor || !hexColor.startsWith('#')) {
+        return 'rgba(15, 23, 42, 0.75)';
+    }
+
+    const normalized = hexColor.replace('#', '');
+    const value = normalized.length === 3
+        ? normalized.split('').map(char => char + char).join('')
+        : normalized.padEnd(6, '0');
+    const red = parseInt(value.slice(0, 2), 16);
+    const green = parseInt(value.slice(2, 4), 16);
+    const blue = parseInt(value.slice(4, 6), 16);
+    const luminance = (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255;
+
+    return luminance > 0.6 ? 'rgba(15, 23, 42, 0.75)' : 'rgba(255, 255, 255, 0.92)';
 }
 
 function wrapPromptText(ctx, text, maxWidth) {

--- a/styles.css
+++ b/styles.css
@@ -234,7 +234,7 @@ body {
 
 .form-row {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 1.5rem;
 }
 
@@ -297,7 +297,7 @@ body {
 }
 
 .custom-color-picker {
-    margin-top: 0.75rem;
+    margin-top: 0;
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -336,7 +336,8 @@ body {
     position: relative;
     border-radius: var(--border-radius);
     overflow: hidden;
-    background: rgba(15, 23, 42, 0.85);
+    background: var(--preview-bg, #ffffff);
+    border: 1px solid rgba(148, 163, 184, 0.35);
     min-height: 320px;
     display: flex;
     align-items: center;
@@ -352,7 +353,7 @@ body {
 
 .preview-placeholder {
     text-align: center;
-    color: rgba(255, 255, 255, 0.9);
+    color: var(--preview-text, rgba(15, 23, 42, 0.75));
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
### Motivation
- Provide a background color control next to the image type selector so users can choose a canvas color when generating text-based images. 
- Make the preview area reflect the chosen background so the placeholder and UI show a faithful representation of the final image. 
- Ensure placeholder text remains readable against arbitrary background colors by computing a contrasting text color. 

### Description
- Moved the `textBackgroundColor` color input into the text-to-picture form row and added an `id="textPreviewFrame"` around the preview frame in `index.html`.
- Updated layout to a four-column row by changing `.form-row` to `grid-template-columns: repeat(4, minmax(0, 1fr))` in `styles.css` and adjusted color picker spacing and preview styling to use CSS variables `--preview-bg` and `--preview-text`.
- Added `textPreviewFrame` handling and an `input` listener for `textBackgroundColor` in `script.js`, plus the functions `updateTextBackgroundPreview` and `getContrastTextColor` to apply the background color and pick readable placeholder text color.
- Kept existing generation and download logic; generating images still uses the selected background via `getSelectedBackgroundColor()` when rendering the canvas.

### Testing
- Launched a local static server using `python -m http.server 8000`, which started successfully and served the site.
- Attempted to capture a UI screenshot with Playwright (automated browser script), but the Playwright run timed out and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950a07cfac48321b3f3b2a6c3a9e9f7)