### PR TITLE
Move background color picker to the left column

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,6 +291,13 @@
                     </div>
                     <div class="form-row">
                         <div class="form-group">
+                            <label for="textBackgroundColor">Background Color</label>
+                            <div class="custom-color-picker">
+                                <input type="color" id="textBackgroundColor" value="#ffffff" aria-label="Background color">
+                            </div>
+                            <span class="field-hint">Controls the preview color on the right.</span>
+                        </div>
+                        <div class="form-group">
                             <label for="textWidthInput">Width (px)</label>
                             <input type="number" id="textWidthInput" min="256" max="2048" value="1024">
                         </div>
@@ -304,12 +311,6 @@
                                 <option value="png">PNG</option>
                                 <option value="jpeg">JPEG</option>
                             </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="textBackgroundColor">Background Color</label>
-                            <div class="custom-color-picker">
-                                <input type="color" id="textBackgroundColor" value="#ffffff" aria-label="Background color">
-                            </div>
                         </div>
                     </div>
                     <div class="form-actions">

--- a/styles.css
+++ b/styles.css
@@ -322,6 +322,13 @@ body {
     color: var(--text-secondary);
 }
 
+.field-hint {
+    display: block;
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
 .text2picture-preview {
     background: linear-gradient(135deg, rgba(99, 102, 241, 0.08), rgba(56, 189, 248, 0.08));
     border-radius: var(--border-radius-lg);


### PR DESCRIPTION
### Motivation
- Improve the text-to-picture form layout by placing the Background Color control on the left for quicker access. 
- Make it clearer that the color picker only affects the preview (right-side preview frame). 
- Provide a short helper hint so users understand the control's effect without guessing. 

### Description
- Reordered the form fields in `index.html` so the `#textBackgroundColor` color input is the leftmost control in the `.form-row`. 
- Added a helper hint `<span class="field-hint">Controls the preview color on the right.</span>` next to the color picker. 
- Added `.field-hint` styling to `styles.css` to match form hint appearance. 
- No JavaScript behavior changes were introduced; preview behavior continues to be driven by the existing `updateTextBackgroundPreview`/`getSelectedBackgroundColor` logic. 

### Testing
- Started a local HTTP server with `python -m http.server 8000` to serve the updated pages as a smoke test. 
- Ran a Playwright-based visual smoke test that captured a screenshot of the `#text-to-picture` area and produced `artifacts/background-color-left.png`, which succeeded after an initial timeout. 
- No unit tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950a40e2b1c8321946de1c56cb50c94)