### PR TITLE
Invalidate stale text-to-picture preview when background color changes

### DIFF
--- a/script.js
+++ b/script.js
@@ -121,6 +121,7 @@ function initializeEventListeners() {
     if (textDownloadBtn) textDownloadBtn.addEventListener('click', downloadGeneratedTextImage);
     if (textBackgroundColor) {
         textBackgroundColor.addEventListener('input', updateTextBackgroundPreview);
+        textBackgroundColor.addEventListener('change', updateTextBackgroundPreview);
         updateTextBackgroundPreview();
     }
     console.log('Event listeners initialized successfully');
@@ -400,7 +401,8 @@ function generateTextToImage(event) {
             url: url,
             width: width,
             height: height,
-            format: selectedFormat
+            format: selectedFormat,
+            backgroundColor: backgroundColor
         };
 
         if (textPreviewImage) {
@@ -463,6 +465,23 @@ function updateTextBackgroundPreview() {
     const textColor = getContrastTextColor(backgroundColor);
     textPreviewFrame.style.setProperty('--preview-bg', backgroundColor);
     textPreviewFrame.style.setProperty('--preview-text', textColor);
+
+    if (generatedTextImageData && generatedTextImageData.backgroundColor !== backgroundColor) {
+        if (generatedTextImageData.url) {
+            URL.revokeObjectURL(generatedTextImageData.url);
+        }
+        generatedTextImageData = null;
+
+        if (textPreviewImage) {
+            textPreviewImage.style.display = 'none';
+        }
+        if (textPreviewPlaceholder) {
+            textPreviewPlaceholder.style.display = 'flex';
+        }
+        if (textDownloadBtn) {
+            textDownloadBtn.disabled = true;
+        }
+    }
 }
 
 function getContrastTextColor(hexColor) {


### PR DESCRIPTION
### Motivation
- The preview could show a previously generated image that used a different background color, causing a mismatch between the selected color and the displayed result.
- The background color picker only listened to `input` events which missed some change scenarios from color pickers or programmatic updates.

### Description
- Added a `change` event listener on `textBackgroundColor` in `initializeEventListeners()` to catch additional selection changes.
- Record the chosen background in `generatedTextImageData.backgroundColor` when an image is rendered so the preview can be validated against the current picker value.
- When the selected background differs from the generated image, revoke the previous object URL, clear `generatedTextImageData`, hide the preview image, show the placeholder, and disable the download button.

### Testing
- Started a local HTTP server on port `8000` to serve the frontend, which launched successfully as an automated step.
- Attempted automated UI verification with Playwright to set the picker and capture a screenshot, but the Playwright run timed out and failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950ac0885388321896eb428d5be5110)