### PR TITLE
Set default text-to-picture image type to JPEG

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,8 +308,8 @@
                         <div class="form-group">
                             <label for="textFormatSelect">Image Type</label>
                             <select id="textFormatSelect">
+                                <option value="jpeg" selected>JPEG</option>
                                 <option value="png">PNG</option>
-                                <option value="jpeg">JPEG</option>
                             </select>
                         </div>
                     </div>


### PR DESCRIPTION
### Motivation
- Make the `Image Type` control in the Text-to-Picture UI default to JPEG so generated images use JPEG by default.
- Preserve existing preview behavior where the `Background Color` picker updates the preview background and text contrast.

### Description
- Update `index.html` to set the JPEG option as selected by adding `<option value="jpeg" selected>JPEG</option>` and reorder the options.
- No changes were required in `script.js` because the generator reads the selected format from `textFormatSelect` at runtime.

### Testing
- No automated unit or integration tests were run for this static content change.
- A Playwright screenshot attempt was executed but timed out and did not complete (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950b50fdaa883218030d1b69ce545c6)