### PR TITLE
Increase background color hint prominence

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -325,8 +325,10 @@ body {
 .field-hint {
     display: block;
     margin-top: 0.5rem;
-    font-size: 0.85rem;
-    color: var(--text-secondary);
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    line-height: 1.4;
 }
 
 .text2picture-preview {


### PR DESCRIPTION
### Motivation
- The background color hint in the Text-to-Picture form was small and low-contrast, making it hard for users to notice and understand the control quickly.

### Description
- Updated `styles.css` to enlarge and emphasize the `.field-hint` used for background color guidance by increasing `font-size` and adding `font-weight` and `line-height` for better readability.
- Changed the hint color to `var(--text-primary)` to improve contrast against the form background.
- This is a purely visual/styling change targeting the text hint in the text-to-picture UI.

### Testing
- Attempted a Playwright visual check by launching a local server and capturing a screenshot of `index.html`, but the Chromium process crashed and the screenshot step failed.
- No other automated tests were executed for this static styling update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950b90f8ce48321ba91c81748edcd2b)