### PR TITLE
Clarify Background Color hint text

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
                             <div class="custom-color-picker">
                                 <input type="color" id="textBackgroundColor" value="#ffffff" aria-label="Background color">
                             </div>
-                            <span class="field-hint">Controls the preview color on the right.</span>
+                            <span class="field-hint">Updates the preview panel background color on the right.</span>
                         </div>
                         <div class="form-group">
                             <label for="textWidthInput">Width (px)</label>


### PR DESCRIPTION
### Motivation
- Improve the clarity of the Background Color field so users understand what UI element it affects.
- Reduce confusion about whether the color controls exported images or the on-screen preview.
- Make a small UX copy update with minimal risk to behavior.

### Description
- Updated the field hint text in `index.html` within the text-to-picture form.
- Replaced the string `"Controls the preview color on the right."` with `"Updates the preview panel background color on the right."`.
- This is a copy-only change and does not modify JavaScript behavior or CSS.

### Testing
- No automated tests were executed for this change.
- The change is a UI copy edit only and does not require runtime tests for functionality.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950cf5e72c483218caf0b30aa84cfb4)