### PR TITLE
Set default Background Color for Text-to-Picture to white

### DIFF
--- a/script.js
+++ b/script.js
@@ -121,6 +121,7 @@ function initializeEventListeners() {
     if (textGenerateBtn) textGenerateBtn.addEventListener('click', generateTextToImage);
     if (textDownloadBtn) textDownloadBtn.addEventListener('click', downloadGeneratedTextImage);
     if (textBackgroundColor) {
+        textBackgroundColor.value = '#ffffff';
         textBackgroundColor.addEventListener('input', updateTextBackgroundPreview);
         textBackgroundColor.addEventListener('change', updateTextBackgroundPreview);
         updateTextBackgroundPreview();


### PR DESCRIPTION
### Motivation
- Ensure the text-to-picture tool has a consistent initial background color so the preview isn't unexpectedly null or mismatched.
- Provide a predictable UX by explicitly initializing the background color control on load.
- Make sure the preview reflects the default color immediately when the page initializes.

### Description
- Set the color input value to white by assigning `textBackgroundColor.value = '#ffffff';` inside `initializeEventListeners` when the element exists.
- Retain adding `input` and `change` listeners and the subsequent call to `updateTextBackgroundPreview()` so the preview updates as before.
- The change is a single-line initialization in `script.js` to enforce the default state for the background control.

### Testing
- No automated tests were run for this change.
- The change is minimal and limited to client-side initialization logic so it should be safe to validate in the browser by loading the page and observing the preview background.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950e142cd7c832195e2182d5a42a671)