### PR TITLE
Add Free Photo Editing Options section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -447,6 +447,33 @@
         </div>
     </section>
 
+    <section class="info-section alt" id="free-photo-tools">
+        <div class="container">
+            <h2 class="section-title">Free Photo Editing Options (No Login Needed)</h2>
+            <p class="section-subtitle">Pick a ready-to-use editor or stay inside our browser-only tools.</p>
+            <div class="info-columns">
+                <div class="info-column">
+                    <h3>Ready-made online editors</h3>
+                    <ul class="info-benefits">
+                        <li><strong>Photopea:</strong> PSD layers, masks, curves, and Photoshop-like workflow.</li>
+                        <li><strong>Pixlr:</strong> Quick crop, color, filters, text, and stickers.</li>
+                        <li><strong>Squoosh:</strong> Local image compression and format conversion.</li>
+                    </ul>
+                </div>
+                <div class="info-column">
+                    <h3>What you can do inside this site</h3>
+                    <ul class="info-benefits">
+                        <li>Resize, reformat, and compress images with quality control.</li>
+                        <li>Export JPG, PNG, or WebP directly from your browser.</li>
+                        <li>Create posters and clean text-based visuals instantly.</li>
+                        <li>Crop or cover watermarks on images you own.</li>
+                    </ul>
+                </div>
+            </div>
+            <p class="section-note">All processing happens locally in your browser for speed and privacy.</p>
+        </div>
+    </section>
+
     <!-- Features Section -->
     <section class="features-section" id="features">
         <div class="container">

--- a/styles.css
+++ b/styles.css
@@ -467,6 +467,62 @@ body {
     background: var(--background);
 }
 
+.info-section {
+    padding: 80px 0;
+    background: var(--background);
+}
+
+.info-section.alt {
+    background: var(--background-alt);
+}
+
+.info-benefits {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.info-benefits li {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    color: var(--text-secondary);
+    font-size: 1.05rem;
+    line-height: 1.6;
+}
+
+.info-benefits li::before {
+    content: '';
+    width: 0.6rem;
+    height: 0.6rem;
+    margin-top: 0.4rem;
+    border-radius: 999px;
+    background: var(--primary-color);
+    flex: 0 0 0.6rem;
+}
+
+.info-columns {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 2rem;
+    margin-top: 2.5rem;
+}
+
+.info-column h3 {
+    font-size: 1.35rem;
+    margin-bottom: 1rem;
+    color: var(--text-primary);
+}
+
+.section-note {
+    margin-top: 2.5rem;
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 1rem;
+}
+
 .section-title {
     text-align: center;
     font-size: 2.5rem;


### PR DESCRIPTION
### Motivation
- Surface external free editors and in-site browser tools so users have easy, no-login options for photo editing.
- Clarify privacy and local processing benefits of using the site for image operations.
- Provide a visually consistent informational block that matches existing site sections.

### Description
- Added a new HTML section with `id="free-photo-tools"` and classes `info-section alt` to `index.html` containing two columns of editor and in-site capability items.
- Introduced shared styles in `styles.css` including `.info-section`, `.info-benefits`, `.info-columns`, `.info-column h3`, and `.section-note` to style the new content.
- Used a responsive grid (`repeat(auto-fit, minmax(240px, 1fr))`) for the columns and a custom bullet marker via `.info-benefits li::before`.

### Testing
- Launched a local server with `python -m http.server 8000` and verified the page loaded successfully.
- Captured a full-page screenshot using a Playwright script which completed and produced `artifacts/free-photo-tools.png` successfully.
- No unit or integration test suite was applicable for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696254e7b60c8321b39b64ed91b22457)